### PR TITLE
[WIP] Use CAS protocol 3.0 for service validation

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,14 @@ config.rack_cas.server_url = 'https://cas.example.com/'
 ```
 If the the server URL depends on your environment, you can define it in the according file: `config/environments/<env>.rb`
 
+### Protocol
+
+Since protocol `p3` the protocol is prepended in certain urls. If you wish to use protocol `p3` set the following config variable
+
+`config.rack_cas.protocol = 'p3'`
+
+[For more info](http://jasig.github.io/cas/4.1.x/protocol/CAS-Protocol-Specification.html#cas-uris)
+
 ### Single Logout ###
 
 If you wish to enable [single logout](http://apereo.github.io/cas/4.0.x/installation/Logout-Single-Signout.html) you'll need to modify your configuration as below.

--- a/lib/rack-cas/configuration.rb
+++ b/lib/rack-cas/configuration.rb
@@ -1,7 +1,8 @@
 module RackCAS
   class Configuration
     SETTINGS = [:fake, :server_url, :session_store, :exclude_path, :exclude_paths, :extra_attributes_filter,
-                :verify_ssl_cert, :renew, :use_saml_validation, :ignore_intercept_validator, :exclude_request_validator]
+                :verify_ssl_cert, :renew, :use_saml_validation, :ignore_intercept_validator, :exclude_request_validator, :protocol]
+
 
     SETTINGS.each do |setting|
       attr_accessor setting

--- a/lib/rack-cas/server.rb
+++ b/lib/rack-cas/server.rb
@@ -41,7 +41,8 @@ module RackCAS
 
     def validate_service_url(service_url, ticket)
       service_url = URL.parse(service_url).remove_param('ticket').to_s
-      @url.dup.append_path('serviceValidate').add_params(service: service_url, ticket: ticket)
+      # @url.dup.append_path('serviceValidate').add_params(service: service_url, ticket: ticket)
+      @url.dup.append_path('p3/serviceValidate').add_params(service: service_url, ticket: ticket)
     end
   end
 end

--- a/lib/rack-cas/server.rb
+++ b/lib/rack-cas/server.rb
@@ -36,13 +36,20 @@ module RackCAS
 
     def saml_validate_url(service_url)
       service_url = URL.parse(service_url).remove_param('ticket').to_s
-      @url.dup.append_path('samlValidate').add_params(TARGET: service_url)
+      @url.dup.append_path(path_for_protocol('samlValidate')).add_params(TARGET: service_url)
     end
 
     def validate_service_url(service_url, ticket)
       service_url = URL.parse(service_url).remove_param('ticket').to_s
-      # @url.dup.append_path('serviceValidate').add_params(service: service_url, ticket: ticket)
-      @url.dup.append_path('p3/serviceValidate').add_params(service: service_url, ticket: ticket)
+      @url.dup.append_path(path_for_protocol('serviceValidate')).add_params(service: service_url, ticket: ticket)
+    end
+
+    def path_for_protocol(path)
+      if RackCAS.config.protocol && RackCAS.config.protocol == "p3"
+        "p3/#{path}"
+      else
+        path
+      end
     end
   end
 end

--- a/lib/rack-cas/service_validation_response.rb
+++ b/lib/rack-cas/service_validation_response.rb
@@ -81,7 +81,7 @@ module RackCAS
       http = Net::HTTP.new(@url.host, @url.inferred_port)
       if @url.scheme == 'https'
         http.use_ssl = true
-        http.verify_mode = RackCAS.config.verify_ssl_cert? ? OpenSSL::SSL::VERIFY_PEER : OpenSSL::SSL::VERIFY_NONE
+        http.verify_mode = RackCAS.config.verify_ssl_cert ? OpenSSL::SSL::VERIFY_PEER : OpenSSL::SSL::VERIFY_NONE
       end
 
       http.start do |conn|


### PR DESCRIPTION
This is only meant as an example. Revert this commit and add a config
option instead. Examine the URI overview at
http://jasig.github.io/cas/4.1.x/protocol/CAS-Protocol-Specification.html#cas-uris
to see what endpoints change between protocol v2.0 and v3.0.
